### PR TITLE
Fixes #1

### DIFF
--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<?php echo str_replace('_', '-', $site->language()->locale()) ?>">
 <head>
 
   <meta charset="utf-8" />


### PR DESCRIPTION
Adds the language code and locale for the current site language to the `lang` attribute of the `html` tag. `str_replace` here is used to replace the underscore to a dash to comply with the W3C Recommendation defined by a 2 primary code (ISO639) for language and 2 letter subcode (ISO3166) for country.

Example: `fr-CA` would represent French language spoken in Canada.